### PR TITLE
chore: update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
       - name: Set up Python "3.12"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Login to Docker Hub
@@ -82,14 +82,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Node 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
       - name: Set up Python "3.12"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install GitHub SSH key
@@ -130,7 +130,7 @@ jobs:
         run: make test
       - name: Upload test output
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cluster-test-output
           path: helium-tmp/projects/cluster-tests/build/screenshots/
@@ -156,9 +156,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Trigger CloudFront deployment to `dev`

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -14,7 +14,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6
- Update `actions/setup-python` from v5 to v6
- Update `actions/upload-artifact` from v4 to v7

These updates ensure compatibility with Node 24 runners and use the latest action versions.

## Test plan
- [x] Verify CI build passes with updated actions
- [x] Confirm artifact upload still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)